### PR TITLE
Adds default secret for plug and play installation

### DIFF
--- a/config/example-config.json
+++ b/config/example-config.json
@@ -27,5 +27,6 @@
 		"sandbox": true,
 		"minimum": 20
 	},
-	"password-tries": 1
+	"password-tries": 1,
+	"secret" : "abc123"
 }


### PR DESCRIPTION
Without this copying `example-config.json => config.json` then `npm start` throws this error.

![screenshot 2016-09-09 at 01 07 07](https://cloud.githubusercontent.com/assets/472589/18371098/c6f6fac4-7629-11e6-8fe3-ac7f249138b7.png)
