### PR TITLE
Adds Documentation about app/ structure

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,3 +28,21 @@ npm start
 
 By default it will then be available on `http://localhost:3001/`
 The port is configurable in the  `config/config.json`
+Creating Apps
+===
+
+The system is built around modular apps. If you're looking to add functionality to the site the best way to do this would by adding an app to the site rather than modifying it's base. This means you're unlikely to mess anything up.
+
+As an example, let's add a login page.
+
+Stub out your app structure within `app/`, this will include:
+
+```
+apps/
+  login/
+    views/
+    app.js
+    config.js
+```
+
+Check out these files to get an idea of how each of these should be structure.


### PR DESCRIPTION
Create a useful introduction for people to get up and running
in contributing adidtional modules to the site.

This could go in a seperate Wiki within GitHub but I think it make's more sense to keep it front and center below the codebase. Perhaps if this becomes more long winded in the future it can be moved.