### PR TITLE
Fix subscription earliest charge date in view

### DIFF
--- a/apps/profile/apps/direct-debit/views/setup-subscription.pug
+++ b/apps/profile/apps/direct-debit/views/setup-subscription.pug
@@ -32,9 +32,10 @@ block contents
 					.col-md-5
 						select( name="day_of_month" )#day_of_month.form-control
 							each date, d in dates
-								option( class= ( date == next_possible_charge_date ? 'selected' : '' ) ) #{ date }
 								if date == next_possible_charge_date
-									| &mdash; Earlist possible charge date
+									option.selected( selected=true ) #{ date } &mdash; Earlist possible charge date
+								else
+									option #{ date }
 							option( value='-1' ) Last day of the month
 						if next_possible_charge_date
 							span#helpBlock.help-block Direct Debits usually take around 7 days to process. Therefore, we've set the charge date to be as early as possible. However if you prefer to pay for your membership on a specific date (eg. the day after payday), please select it here. Note that this will delay the start of your membership.


### PR DESCRIPTION
I created a subscription today but I was surprised to find that the 1st of the month was the earliest date.

After looking into this, it seems that the pug wasn't quite as intended. This PR makes it work as I'd expect and automatically selects the correct date (I hard-coded 19th to test) and adds the label (see image).

![screenshot from 2017-08-04 22-15-19](https://user-images.githubusercontent.com/119412/28987288-820f195e-7962-11e7-98c9-09b948dea9f7.png)
