### PR TITLE
Optional syslog

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,15 +28,22 @@ var Options = require( __js + '/options' )();
 app.use( Options.load );
 
 // Bunyan logging
-var requestLogger = bunyan.createLogger( {
+var bunyanConfig = {
 	name: 'Membership-System',
-	streams: [ {
+	streams: []
+};
+
+if (config.log != undefined)
+{
+	bunyanConfig.streams.push({
 		type: "rotating-file",
 		path: config.log,
 		period: '1d', // rotates every day
 		count: 7 // keeps 7 days
-	} ]
-} );
+	})
+}
+
+var requestLogger = bunyan.createLogger( bunyanConfig );
 
 app.use( bunyanMiddleware( { logger: requestLogger } ) );
 

--- a/app.js
+++ b/app.js
@@ -72,7 +72,7 @@ if (config.syslog == true) {
 }
 
 var requestLogger = bunyan.createLogger( bunyanConfig );
-requestLogger.error({foo: 'bar'}, 'hello %s', 'world');
+
 app.use( bunyanMiddleware( { logger: requestLogger } ) );
 
 var app_loader = require( __js + '/app-loader' );

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "body-parser": "^1.14.1",
     "bunyan": "^1.8.12",
     "bunyan-middleware": "^0.8.0",
+    "bunyan-syslog-unixdgram": "^1.0.2",
     "connect-mongodb-session": "^1.3.0",
     "cookie-parser": "^1.4.0",
     "csurf": "^1.9.0",


### PR DESCRIPTION
Added the ability for logs to be sent to the local syslog (if desired).  

Set this by setting ```config.syslog = true```

Only OS X and Linux are currently supported. 

This PR is dependant on #212 (merge that one first!)