### PR TITLE
Bunyan logging req.log with sensitive data support

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ app.use( Options.load );
 var app_loader = require( __js + '/app-loader' );
 
 // Add logging capabilities
-app.use( require( __js + '/logging' ) );
+require( __js + '/logging' )( app );
 
 // Use helmet
 app.use( helmet() );

--- a/app.js
+++ b/app.js
@@ -20,62 +20,15 @@ var express = require( 'express' ),
 	helmet = require( 'helmet' ),
 	flash = require( 'express-flash' ),
 	app = express(),
-	bunyan = require('bunyan'),
-	bunyanMiddleware = require('bunyan-middleware'),
-	SyslogStream = require('bunyan-syslog-unixdgram'),
 	http = require( 'http' ).Server( app );
 
 var Options = require( __js + '/options' )();
 app.use( Options.load );
 
-// Bunyan logging
-var bunyanConfig = {
-	name: 'Membership-System',
-	streams: []
-};
-
-if (config.log != undefined) {
-	bunyanConfig.streams.push({
-		type: "rotating-file",
-		path: config.log,
-		period: '1d', // rotates every day
-		count: 7 // keeps 7 days
-	})
-}
-
-if (config.syslog == true) {
-	var streamOptions = {
-		path: '/var/run/syslog'
-	}
-
-	var supported = true;
-	switch ( process.platform ) {
-		case 'darwin':
-			streamOptions.path = '/var/run/syslog';
-			break;
-		case 'linux':
-			streamOptions.path = '/dev/log';
-			break;
-		default:
-			console.error( "syslog output only supported on Linux and OS X" );
-			supported = false
-	}
-
-	if ( supported ) {
-		var stream = new SyslogStream( streamOptions );
-		bunyanConfig.streams.push( {
-			level: 'debug',
-			type: 'raw',
-			stream: stream
-		} );
-	}
-}
-
-var requestLogger = bunyan.createLogger( bunyanConfig );
-
-app.use( bunyanMiddleware( { logger: requestLogger } ) );
-
 var app_loader = require( __js + '/app-loader' );
+
+// Add logging capabilities
+app.use( require( __js + '/logging' ) );
 
 // Use helmet
 app.use( helmet() );

--- a/config/example-config.json
+++ b/config/example-config.json
@@ -37,5 +37,6 @@
 	"password-tries": 3,
 	"iterations": 50000,
 	"dev": true,
-	"log": "/var/log/membership.log"
+	"log": "/var/log/membership.log",
+	"logStdout": false
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "thirty-two": "^1.0.2"
   },
   "scripts": {
-    "start": "node app",
+    "start": "node app | bunyan -c 'this.sensitive == false'",
     "webhook": "node webhook.js",
     "production": "npm-run-all --parallel start webhook",
     "first-time": "node tools/first-time/first-time",

--- a/src/js/logging.js
+++ b/src/js/logging.js
@@ -1,0 +1,69 @@
+var __root = '../..';
+var __config = __root + '/config/config.json';
+var __static = __root + '/static';
+var __src = __root + '/src';
+var __views = __src + '/views';
+var __js = __src + '/js';
+
+var config = require( __config );
+
+var bunyan = require( 'bunyan' ),
+	bunyanMiddleware = require( 'bunyan-middleware' ),
+	SyslogStream = require( 'bunyan-syslog-unixdgram' )
+
+
+// Bunyan logging
+var bunyanConfig = {
+	name: 'Membership-System',
+	streams: []
+};
+
+if ( config.logStdout != undefined ) {
+	bunyanConfig.streams.push(
+		{
+			level: 'debug',
+			stream: process.stdout
+		}
+	)
+}
+
+if ( config.log != undefined ) {
+	bunyanConfig.streams.push({
+		type: "rotating-file",
+		path: config.log,
+		period: '1d', // rotates every day
+		count: 7 // keeps 7 days
+	})
+}
+
+if (config.syslog == true) {
+	var streamOptions = {
+		path: '/var/run/syslog'
+	}
+
+	var supported = true;
+	switch ( process.platform ) {
+		case 'darwin':
+			streamOptions.path = '/var/run/syslog';
+			break;
+		case 'linux':
+			streamOptions.path = '/dev/log';
+			break;
+		default:
+			console.error( "syslog output only supported on Linux and OS X" );
+			supported = false
+	}
+
+	if ( supported ) {
+		var stream = new SyslogStream( streamOptions );
+		bunyanConfig.streams.push( {
+			level: 'debug',
+			type: 'raw',
+			stream: stream
+		} );
+	}
+}
+
+var requestLogger = bunyan.createLogger( bunyanConfig );
+
+module.exports =  bunyanMiddleware( { logger: requestLogger } );


### PR DESCRIPTION
Progress on better logging #195 - you can now use req.log to access bunyan in routes.  If you specifiy something in ```sensitive``` it will be logged twice, once with the senstive field and once without

```
				req.log.info({
					process: 'login',
					action: 'user_requires_2fa',
					sensitive: {
					user: req.user}
				})
```