### PR TITLE
Options now loads from the DB on every page load

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,13 @@ RUN apk add --update \
     python-dev \
     py-pip \
     build-base
-	 
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
-
-ADD ./ /usr/src/app/
+ADD package.json /usr/src/app/package.json
 RUN npm install --devDependencies
+ADD ./ /usr/src/app/
+
 
 EXPOSE 3001
 EXPOSE 3002

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:8.9-alpine
-
+RUN apk add --update \
+    python \
+    python-dev \
+    py-pip \
+    build-base
+	 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -38,6 +38,7 @@ var Options = {
 			return;
 		}
 	},
+	// {'key':'theKEy','value':'avalue'}
 	getBool: function( key ) {
 		var option = _options.find( function( opt ) {
 			if ( opt.key == key ) return opt;
@@ -89,22 +90,10 @@ var Options = {
 	},
 	load: function( req, res, next ) {
 		res.locals.Options = Options.getText;
-		next();
-	}
-};
-
-module.exports = function() {
-	if ( global.MS_Options == undefined ) {
-		var defaultKeys = Object.keys( defaults );
-
-		defaultKeys.forEach( function( key ) {
-			_options.push( {
-				key: key,
-				value: defaults[ key ],
-				default: true
-			} );
-		} );
-
+		Options.loadFromDb(next);
+	},
+	loadFromDb: function (callback)
+	{
 		OptionsDB.find( function( err, opts ) {
 			for ( var o in opts ) {
 				var option = opts[o];
@@ -115,8 +104,24 @@ module.exports = function() {
 					}
 				} )
 			}
+			callback();
 		} );
+	},
+	firstTime: function () {
+		var defaultKeys = Object.keys( defaults );
+		defaultKeys.forEach( function( key ) {
+			_options.push( {
+				key: key,
+				value: defaults[ key ],
+				default: true
+			} );
+		} );
+	}
+};
 
+module.exports = function() {
+	if ( global.MS_Options == undefined ) {
+		Options.firstTime();
 		global.MS_Options = Options;
 	}
 	return global.MS_Options;

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -33,6 +33,7 @@ var Options = {
 			if ( opt.key == key ) return opt;
 		} );
 		if ( option ) {
+			console.log(option.value)
 			return parseInt( option.value );
 		} else {
 			return;
@@ -122,6 +123,7 @@ var Options = {
 module.exports = function() {
 	if ( global.MS_Options == undefined ) {
 		Options.firstTime();
+		Options.loadFromDb();
 		global.MS_Options = Options;
 	}
 	return global.MS_Options;

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -123,7 +123,6 @@ var Options = {
 module.exports = function() {
 	if ( global.MS_Options == undefined ) {
 		Options.firstTime();
-		Options.loadFromDb();
 		global.MS_Options = Options;
 	}
 	return global.MS_Options;

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -33,13 +33,11 @@ var Options = {
 			if ( opt.key == key ) return opt;
 		} );
 		if ( option ) {
-			console.log(option.value)
 			return parseInt( option.value );
 		} else {
 			return;
 		}
 	},
-	// {'key':'theKEy','value':'avalue'}
 	getBool: function( key ) {
 		var option = _options.find( function( opt ) {
 			if ( opt.key == key ) return opt;

--- a/webhook.js
+++ b/webhook.js
@@ -20,6 +20,9 @@ var config = require( __config ),
 	textBodyParser = bodyParser.text( { type: 'application/json' } ),
 	GoCardless = require( __js + '/gocardless' )( config.gocardless );
 
+// add logging capabilities
+require( __js + '/logging' )( app );
+
 var Options = require( __js + '/options' )();
 
 var Members = db.Members,
@@ -214,40 +217,43 @@ function grantMembership( member ) {
 		}
 	} );
 }
-Options.loadFromDb(function (){
-	setTimeout( function() { checkMembershipCap(); }, 250 );
 
-	function checkMembershipCap() {
-		console.log(Options.getInt( 'signup-cap' ))
+setInterval(function () {
+	Options.loadFromDb(function (){
 		if ( Options.getInt( 'signup-cap' ) > 0 ) {
-			Permissions.find( function( err, permissions ) {
-				var filter_permissions = [];
-				var member = permissions.filter( function( permission ) {
-					if ( permission.slug == config.permission.member ) return true;
-					return false;
-				} )[0];
+			if ( ! Options.getBool( 'signup-closed' ) )
+			{
+				Permissions.find( function( err, permissions ) {
+					var filter_permissions = [];
+					var member = permissions.filter( function( permission ) {
+						if ( permission.slug == config.permission.member ) return true;
+						return false;
+					} )[0];
 
-				var search = { permissions: {
-					$elemMatch: {
-						permission: member._id,
-						date_added: { $lte: new Date() },
-						$or: [
-							{ date_expires: null },
-							{ date_expires: { $gt: new Date() } }
-						]
-					}
-				} };
+					var search = { permissions: {
+						$elemMatch: {
+							permission: member._id,
+							date_added: { $lte: new Date() },
+							$or: [
+								{ date_expires: null },
+								{ date_expires: { $gt: new Date() } }
+							]
+						}
+					} };
 
-				Members.count( search, function( err, total ) {
-					if ( total >= Options.getInt( 'signup-cap' ) ) {
-						Options.set( 'signup-closed', 'true', function () {} );
-						Options.set( 'signup-cap', '0' , function () {});
-					}
+					Members.count( search, function( err, total ) {
+						if ( total >= Options.getInt( 'signup-cap' ) ) {
+							console.log("Total members " + total + " is >= ", Options.getInt( 'signup-cap' ), " signup-cap, and therefore setting signup-closed to true")
+							Options.set( 'signup-closed', 'true', function () {} );
+							Options.set( 'signup-cap', '0' , function () {});
+						}
+					} );
 				} );
-			} );
+			}
 		}
-	}
-});
+	});
+},30*1000);
+
 
 
 function sendNewMemberEmail( member ) {

--- a/webhook.js
+++ b/webhook.js
@@ -214,37 +214,41 @@ function grantMembership( member ) {
 		}
 	} );
 }
-setTimeout( function() { checkMembershipCap(); }, 250 );
+Options.loadFromDb(function (){
+	setTimeout( function() { checkMembershipCap(); }, 250 );
 
-function checkMembershipCap() {
-	if ( Options.getInt( 'signup-cap' ) > 0 ) {
-		Permissions.find( function( err, permissions ) {
-			var filter_permissions = [];
-			var member = permissions.filter( function( permission ) {
-				if ( permission.slug == config.permission.member ) return true;
-				return false;
-			} )[0];
+	function checkMembershipCap() {
+		console.log(Options.getInt( 'signup-cap' ))
+		if ( Options.getInt( 'signup-cap' ) > 0 ) {
+			Permissions.find( function( err, permissions ) {
+				var filter_permissions = [];
+				var member = permissions.filter( function( permission ) {
+					if ( permission.slug == config.permission.member ) return true;
+					return false;
+				} )[0];
 
-			var search = { permissions: {
-				$elemMatch: {
-					permission: member._id,
-					date_added: { $lte: new Date() },
-					$or: [
-						{ date_expires: null },
-						{ date_expires: { $gt: new Date() } }
-					]
-				}
-			} };
+				var search = { permissions: {
+					$elemMatch: {
+						permission: member._id,
+						date_added: { $lte: new Date() },
+						$or: [
+							{ date_expires: null },
+							{ date_expires: { $gt: new Date() } }
+						]
+					}
+				} };
 
-			Members.count( search, function( err, total ) {
-				if ( total >= Options.getInt( 'signup-cap' ) ) {
-					Options.set( 'signup-closed', 'true' );
-					Options.set( 'signup-cap', '0' );
-				}
+				Members.count( search, function( err, total ) {
+					if ( total >= Options.getInt( 'signup-cap' ) ) {
+						Options.set( 'signup-closed', 'true', function () {} );
+						Options.set( 'signup-cap', '0' , function () {});
+					}
+				} );
 			} );
-		} );
+		}
 	}
-}
+});
+
 
 function sendNewMemberEmail( member ) {
 	Mail.sendMail(


### PR DESCRIPTION
This PR modifies the way Options works, such that every time the middleware is loaded (i.e. for every request), it extracts a full set of options from the database - rather than just when the object is first created. 

This means that options are consistent between processes, so for example the webhook process will share the same set of options as the main application.  

Additionally, the webhook process now checks the membership cap every 30 seconds and closes signups (sets `signup-closed` to `true`) if the total number of members is above `signup-cap`.  It also logs the fact it's done this to the console.  