### PR TITLE
Added anonymised session ID and user id to logs by default

### DIFF
--- a/src/js/logging.js
+++ b/src/js/logging.js
@@ -11,6 +11,9 @@ var bunyan = require( 'bunyan' ),
 	bunyanMiddleware = require( 'bunyan-middleware' ),
 	SyslogStream = require( 'bunyan-syslog-unixdgram' )
 
+var crypto = require('crypto')
+var hash = crypto.createHash;
+var randomKey = crypto.randomBytes(256);
 
 // Bunyan logging
 var bunyanConfig = {
@@ -72,8 +75,27 @@ if (config.syslog == true) {
 
 function loggingMiddleware(req, res, next) {
 	var log = req.log;
-	function logAThing( level, params )
+	function logAThing( level, params, req )
 	{
+		params.ip = req.connection.remoteAddress; //TODO: this will only be correct when behind a reverse proxy, if app.set('trust proxy') is enabled!
+		if (! params.sensitive )
+		{
+			params.sensitive = {};
+		}
+		if ( req.user ) {
+			params.sensitive.user = {
+				uuid: req.user.uuid,
+				firstname: req.user.firstname,
+				lastname: req.user.lastname,
+				email: req.user.email
+			};
+			params.anon_userid = hash('sha1').update(req.user.uuid + randomKey).digest('base64');
+		}
+		if ( req.sessionID )
+		{
+			params.sensitive.sessionID = req.sessionID;
+			params.anon_sessionId = hash('sha1').update(req.sessionID + randomKey).digest('base64');
+		}
 		if (params.sensitive)
 		{
 			log[level](params);
@@ -85,19 +107,19 @@ function loggingMiddleware(req, res, next) {
 	req.log = {
 		info: function (params)
 		{
-			logAThing( 'info', params );
+			logAThing( 'info', params , req );
 		},
 		debug: function (params)
 		{
-			logAThing( 'debug', params );
+			logAThing( 'debug', params , req );
 		},
 		error: function (params)
 		{
-			logAThing( 'error', params );
+			logAThing( 'error', params , req );
 		},
 		fatal: function (params)
 		{
-			logAThing( 'fatal', params );
+			logAThing( 'fatal', params , req );
 		}
 	}
 	next();

--- a/src/js/logging.js
+++ b/src/js/logging.js
@@ -83,7 +83,7 @@ function loggingMiddleware(req, res, next) {
 			params.sensitive = {};
 		}
 		if ( req.user ) {
-			params.sensitive.user = {
+			params.sensitive._user = {
 				uuid: req.user.uuid,
 				firstname: req.user.firstname,
 				lastname: req.user.lastname,


### PR DESCRIPTION
To address #276 

When the app first starts, a random string is generated.  This is used as a basic salt, which is added to the user UUID and session IDs before hashing and displaying in the non-sensitive section of the log.  

This should allow for users to have actions tracked without revealing their identity in the non-sensitive logs.  