### PR TITLE
logging.js now exports a method to install express middleware and the logger

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ app.use( Options.load );
 var app_loader = require( __js + '/app-loader' );
 
 // Add logging capabilities
-require( __js + '/logging' )( app );
+require( __js + '/logging' ).installMiddleware( app );
 
 // Use helmet
 app.use( helmet() );

--- a/src/js/logging.js
+++ b/src/js/logging.js
@@ -70,6 +70,8 @@ if (config.syslog == true) {
 	}
 }
 
+var logger = bunyan.createLogger( bunyanConfig );
+
 function loggingMiddleware(req, res, next) {
 	var log = req.log;
 	function logAThing( level, params )
@@ -103,10 +105,10 @@ function loggingMiddleware(req, res, next) {
 	next();
 }
 
-var requestLogger = bunyan.createLogger( bunyanConfig );
-
-
-module.exports = function (app) {
-	app.use( bunyanMiddleware( { logger: requestLogger, level: "trace" } ) );
-	app.use( loggingMiddleware );
+module.exports = {
+	installMiddleware: function (app) {
+		app.use( bunyanMiddleware( { logger: logger, level: "trace" } ) );
+		app.use( loggingMiddleware );
+	},
+	log: logger
 }

--- a/webhook.js
+++ b/webhook.js
@@ -21,7 +21,7 @@ var config = require( __config ),
 	GoCardless = require( __js + '/gocardless' )( config.gocardless );
 
 // add logging capabilities
-require( __js + '/logging' )( app );
+require( __js + '/logging' ).installMiddleware( app );
 
 var Options = require( __js + '/options' )();
 


### PR DESCRIPTION
This is to help with issue #277, which means that we can import the logger like this:
```
var log = require('src/logging').log;
log.info('this is some information')
```

Or install the express middleware like this:
```
// Add logging capabilities
require( __js + '/logging' ).installMiddleware( app );
```