### PR TITLE
Updated Postcodes.IO client to the latest (non broken) version

### DIFF
--- a/apps/members/app.js
+++ b/apps/members/app.js
@@ -277,7 +277,7 @@ app.post( '/:uuid/profile', auth.isSuperAdmin, function( req, res ) {
 	if ( results ) {
 		postcode = results[0];
 	}
-	postcodes.lookup( postcode, function( err, data ) {
+	postcodes.lookup( postcode ).then( function( err, data ) {
 		var member = {
 			firstname: req.body.firstname,
 			lastname: req.body.lastname,

--- a/apps/profile/app.js
+++ b/apps/profile/app.js
@@ -194,7 +194,7 @@ app.post( '/update', auth.isLoggedIn, function( req, res ) {
 		return;
 	}
 
-	postcodes.lookup( postcode, function( err, data ) {
+	postcodes.lookup( postcode ).then( function( err, data ) {
 		var profile = {
 			firstname: req.body.firstname,
 			lastname: req.body.lastname,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1713,6 +1713,14 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
     "errno": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
@@ -1975,6 +1983,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "fetch-everywhere": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fetch-everywhere/-/fetch-everywhere-1.0.5.tgz",
+      "integrity": "sha1-skl/R6V9kCazkHwJdWrPX0vTTos=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.4"
+      }
     },
     "figures": {
       "version": "2.0.0",
@@ -3183,8 +3200,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -3232,6 +3248,17 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
+    },
+    "json-client": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/json-client/-/json-client-0.8.5.tgz",
+      "integrity": "sha512-37F5UjQXGGZ2+IzDZLFwThY66WY+w9CGR3z1T3Er0/a8t4hF87FUiBUL4ElI43Sc0Byi4ZVQsrdnPRDZic8R9Q==",
+      "requires": {
+        "fetch-everywhere": "1.0.5",
+        "object-merge": "2.5.1",
+        "qs": "6.5.1",
+        "url": "0.11.0"
+      }
     },
     "json-parse-better-errors": {
       "version": "1.0.1",
@@ -4005,6 +4032,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.0.0.tgz",
       "integrity": "sha1-ICtIAhoMTL3i34DeFaF0Q8i0OYA="
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
     },
     "node-pre-gyp": {
       "version": "0.6.39",
@@ -5085,13 +5121,18 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "postcode": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/postcode/-/postcode-0.2.5.tgz",
+      "integrity": "sha1-HBiTp7baLqXI8Zv/FYWTrIFQLHg="
+    },
     "postcodesio-client": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/postcodesio-client/-/postcodesio-client-0.1.2.tgz",
-      "integrity": "sha1-iO5mmMnRVJicZgFDCHbLORKYo3w=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/postcodesio-client/-/postcodesio-client-0.3.3.tgz",
+      "integrity": "sha512-HdyAccKkQuur16XAjPH1WMOQtlrvKfDpDX8Sk3tREoZaUcBMgl41kMQ/bfvkdGG2I2E3Ykrw805IKQzfxCq2gA==",
       "requires": {
-        "object-merge": "2.5.1",
-        "q": "1.5.1"
+        "json-client": "0.8.5",
+        "postcode": "0.2.5"
       }
     },
     "prepend-http": {
@@ -5316,7 +5357,8 @@
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
     },
     "qs": {
       "version": "6.5.1",
@@ -5335,8 +5377,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -6876,7 +6917,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -6885,8 +6925,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },
@@ -7086,6 +7125,11 @@
           "dev": true
         }
       }
+    },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "which": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
     "passport-totp": "0.0.2",
-    "postcodesio-client": "^0.1.2",
+    "postcodesio-client": "^0.3.3",
     "pug": "^2.0.0-beta11",
     "query-string": "^4.3.4",
     "request": "^2.70.0",


### PR DESCRIPTION
The new version uses Promises now instead of callbacks so some code needed to be modified.  It now works like this:

```
postcodes.lookup ( "W1A 1AA" ).then (function  ( err, data ) {
// do stuff here
})
```

Refer to #203 as the general "get dependencies up to date" ticket