### PR TITLE
Don't include node_modules in docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/*


### PR DESCRIPTION
Because the dependencies need to be installed inside the docker image, not copied from the host. 