### PR TITLE
Initial version of privacy consent in join form only

### DIFF
--- a/apps/join/app.js
+++ b/apps/join/app.js
@@ -57,6 +57,20 @@ app.post( '/', function( req, res ) {
 			address: req.body.address,
 		};
 
+		if ( ! req.body.data_consent ) {
+			req.flash( 'danger', 'consent-required' );
+			res.session.joinForm = user;
+			res.redirect( app.mountpath );
+			req.log.debug({
+				app: 'join',
+				action: 'signup',
+				error: 'Data consent not ticked'
+			})
+			return
+		} else {
+			user.data_consent = new Date();
+		}
+
 		if ( ! req.body.email ) {
 			req.flash( 'danger', 'user-email' );
 			req.session.joinForm = user;

--- a/apps/join/views/index.pug
+++ b/apps/join/views/index.pug
@@ -33,6 +33,12 @@ block contents
 				+input( 'text', 'First Name', 'firstname', { value: user.firstname, required: true, left: 3, right: 4 } )
 				+input( 'text', 'Last Name', 'lastname', { value: user.lastname,  required: true, left: 3, right: 4 } )
 				+input( 'textarea', 'Address', 'address', { value: user.address, required: true, left: 3, right: 4 } )
+				+page_header( 'Privacy Consent' )
+				p #{ Options( 'privacy-consent' ) }
+				p If you consent to us processing your data according to this policy, tick the box below
+				label( for="data_consent" )
+					input( type="checkbox", name="data_consent", checked=( false ), required=( true ) )#data_consent
+					| I consent processing my data in accordance with this policy
 				+form_button( 'Next', 'primary', { left: 3 } )
 		.col-md-4
 			+page_header( 'Existing member' )

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -176,5 +176,8 @@
 	"flash-enroll-dupe": "Tag already enrolled",
 	"flash-enroll-error": "Error enrolling tag",
 
-	"flash-signup-closed": "Signups are currently closed"
+	"flash-signup-closed": "Signups are currently closed",
+
+	"flash-consent-required": "You need to consent to us processing your data in order to become a member",
+	"privacy-consent": "We take your privacy seriously and will only use your personal information to administer your account as required by UK law. A selection of your information will be available to other paid up members (name and email address). Your contact details may be used by the organisation (or agents acting on behalf of the organisation) to contact you regarding important matters. "
 }

--- a/src/models/members.js
+++ b/src/models/members.js
@@ -170,7 +170,12 @@ module.exports = {
 				default: false
 			}
 		} ],
-		last_seen: Date
+		last_seen: Date,
+		data_consent: {
+			type: Date,
+			default: Date.now,
+			required: true
+		}
 	} )
 };
 


### PR DESCRIPTION
Records a date on which consent was given.  

Still need to add this to the new-user script, as well as provide a way for existing users to give consent.  

Some advice on the default text would be good too. 