### PR TITLE
Fixing logging for remote proxies

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,6 +50,10 @@ app.set( 'views', __views );
 app.set( 'view engine', 'pug' );
 app.set( 'view cache', false );
 
+// Set reverse proxy trust (see http://expressjs.com/en/guide/behind-proxies.html)
+// default to false
+app.set( 'trust proxy', config.reverseProxyTrust || false )
+
 // Load apps
 app_loader( app );
 

--- a/config/example-config.json
+++ b/config/example-config.json
@@ -38,5 +38,6 @@
 	"iterations": 50000,
 	"dev": true,
 	"log": "/var/log/membership.log",
-	"logStdout": false
+	"logStdout": false,
+	"reverseProxyTrust":"loopback"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,8 @@ services:
      image: ministryofjustice/mailcatcher
      ports:
        - "1080:1080"
+   proxy:
+     image: nginx
+     build: ./nginx/
+     ports:
+       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,5 @@ services:
      build: ./nginx/
      ports:
        - "8080:8080"
+     depends_on:
+       - membership

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx
+COPY membership.conf /etc/nginx/conf.d/membership.conf

--- a/nginx/membership.conf
+++ b/nginx/membership.conf
@@ -1,0 +1,11 @@
+server {
+  server_name localhost;
+  listen 8080;
+  location / {
+    proxy_set_header HOST $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass  http://membership:3001;
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -53,3 +53,6 @@ Stub out your app structure within `app/`, this will include:
 
 
 Check out these files to get an idea of how each of these should be structure.
+
+## Reverse proxy
+If running behind a reverse proxy, you should configure your proxy to add the `X-Forwarded-*` headers (see [nginx documentation](https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/)), and also set reverseProxyTrust variable in `config/config.json`

--- a/src/js/logging.js
+++ b/src/js/logging.js
@@ -79,7 +79,7 @@ function loggingMiddleware(req, res, next) {
 	var log = req.log;
 	function logAThing( level, params, req )
 	{
-		params.ip = req.connection.remoteAddress; //TODO: this will only be correct when behind a reverse proxy, if app.set('trust proxy') is enabled!
+		params.ip = req.ip; //TODO: this will only be correct when behind a reverse proxy, if app.set('trust proxy') is enabled!
 		if (! params.sensitive )
 		{
 			params.sensitive = {};


### PR DESCRIPTION
Addressing #286 , the IP logged using the logging functions now make use of req.ip, which is populated with the remote IP when trust proxy is turned on.  